### PR TITLE
Fixes #8 - AssertString:IsNotNullOrEmpty does not use failMessage

### DIFF
--- a/src/OEUnit/Assertion/AssertStringType.i
+++ b/src/OEUnit/Assertion/AssertStringType.i
@@ -38,8 +38,8 @@
     throws an AssertionFailedError with the given failMessage.
   ----------------------------------------------------------------------------*/
   METHOD STATIC VOID IsNotNullOrEmpty(INPUT val AS {&DataType}, INPUT failMessage AS CHARACTER):
-    Assert:IsNotNull(val).
-    Assert:AreNotEqual(val, "").
+    Assert:IsNotNull(val, failMessage).
+    Assert:AreNotEqual(val, "", failMessage).
   END METHOD.  
 
   /*----------------------------------------------------------------------------


### PR DESCRIPTION
- Pass failMessage parameter to Assert methods called in this method.
  This pull request fixes #8 and fixes #9 (sorry for the duplication on the tickets!)
