### PR TITLE
Implement Fixtures to import data from specified DataSets per Test

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -17,6 +17,7 @@
                     <li><a href="runningtests.html">Running a Test</a></li>
                     <li><a href="reportingtests.html">Reporting Test Results</a></li>
                     <li><a href="dataprovider.html">DataProviders</a></li>
+                    <li><a href="fixtures.html">Fixtures</a></li>
                     <li><a href="license.html">License</a></li>
                     <li>Change Log</li>
                 </ul>

--- a/doc/dataprovider.html
+++ b/doc/dataprovider.html
@@ -17,6 +17,7 @@
                     <li><a href="runningtests.html">Running a Test</a></li>
                     <li><a href="reportingtests.html">Reporting Test Results</a></li>
                     <li>DataProviders</li>
+                    <li><a href="fixtures.html">Fixtures</a></li>
                     <li><a href="license.html">License</a></li>
                     <li><a href="changelog.html">Change Log</a></li>
                 </ul>

--- a/doc/fixtures.html
+++ b/doc/fixtures.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <title>OEUnit - Fixtures</title>
+</head>
+<body>
+    <table class="menu" cellpadding="10" cellspacing="0">
+        <tr>
+            <td>
+                <h2>OEUnit - Unit Testing Framework</h2>
+                <ul class="menuItems">
+                    <li><a href="index.html">Overview</a></li>
+                    <li><a href="installation.html">Installation</a></li>
+                    <li><a href="testcase.html">Writing a Test Case</a></li>
+                    <li><a href="testsuite.html">Writing a Test Suite</a></li>
+                    <li><a href="runningtests.html">Running a Test</a></li>
+                    <li><a href="reportingtests.html">Reporting Test Results</a></li>
+                    <li><a href="dataprovider.html">DataProviders</a></li>
+                    <li>Fixtures</li>
+                    <li><a href="license.html">License</a></li>
+                    <li><a href="changelog.html">Change Log</a></li>
+                </ul>
+            </td>
+        </tr>
+    </table>
+    <h1>
+        Fixtures
+    </h1>
+    <h2>What are Fixtures?</h2>
+    <p>
+        A fixture is an object that inserts, or creates, data into one or more database tables before
+        a unit test is run. At the end of the test, the fixture data is removed.<br />
+        <br />
+        A test method declares that is requires a Fixture when it is defined, using the <code>fixture</code>
+        attribute, supplying the name of a fixture class method as the attribute value.<br />
+        <br />
+        A class method is defined in the test case, with the <code class="keyword">@Fixture</code> 
+        annotation, with an optional <code>name</code> attribute. This method returns an object of type 
+        <code>OEUnit.Data.Fixture</code> which will contain the data to be loaded into a database when required.
+    </p>
+    <h2>How to use a Fixture</h2>
+    <p>
+        1. Define a test method, using the <code>fixture</code> attribute to specify the name of a class method 
+        which will provide a fixture object.<br />
+        For example:</p>
+    <pre class="code"> <span class="keyword">ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+ USING</span> OEUnit.Assertion.Assert.
+ <span class="keyword">USING</span> OEUnit.Data.Fixture.
+
+ <span class="keyword">CLASS</span> SimpleTest:
+   
+   @Test (fixture=OrderStatusFixture). 
+   <span class="keyword">METHOD PUBLIC VOID</span> AcceptStatusChange(): 
+     <span class="keyword">DEFINE VARIABLE</span> result <span class="keyword">AS LOGICAL NO-UNDO.</span>
+     <span class="keyword">FIND FIRST</span> Order 
+          <span class="keyword">WHERE</span> Order.Status = "NEW" <span class="keyword">NO-LOCK NO-ERROR</span>.
+     Order:OpenOrder(Order.OrderNo).
+     result = Order:ChangeStatus(INPUT "ACCEPTED"). 
+     Assert:AreEqual(result,<span class="literal">TRUE</span>).
+   <span class="keyword">END METHOD</span>.    
+
+ <span class="keyword">END CLASS</span>.</pre>
+    <p>
+        <br />
+        2. Add a method to the class which returns an OEUnit.Data.Fixture object.<br />
+        Use the <code class="keyword">@Fixture</code> annotation to indicate that the class is a Fixture method.<br/>
+        For example:</p>
+   <pre class="code">   @Fixture. 
+   <span class="keyword">METHOD PUBLIC </span>Fixture OrderStatusFixture(): 
+     <span class="keyword">DEFINE VARIABLE</span> fixture <span class="keyword">AS</span> Fixture <span class="keyword">NO-UNDO</span>.
+     fixture = <span class="keyword">NEW</span> Fixture().
+     fixture:FromJSON(<span class="literal">"~{ ~"Order~": ["
+                      + "~{ ~"OrderNo~": ~"10000~", ~"CustomerNo~": 99000, ~"Status~": ~"COMPLETED~"},"
+                      + "~{ ~"OrderNo~": ~"10001~", ~"CustomerNo~": 99001, ~"Status~": ~"CANCELLED~"},"
+                      + "~{ ~"OrderNo~": ~"10002~", ~"CustomerNo~": 99002, ~"Status~": ~"COMPLETED~"},"
+                      + "~{ ~"OrderNo~": ~"10003~", ~"CustomerNo~": 99000, ~"Status~": ~"NEW~"},
+                      + "~{ ~"OrderNo~": ~"10004~", ~"CustomerNo~": 99003, ~"Status~": ~"ACCEPTED~"},"
+                      + "~{ ~"OrderNo~": ~"10005~", ~"CustomerNo~": 99004, ~"Status~": ~"PAID~"},"
+                      + "]}"</span>).
+     <span class="keyword">RETURN</span> fixture.
+   <span class="keyword">END METHOD</span>.</pre> <p class="important">
+        <b>
+            <br />
+            Important Notes:</b></p>
+    <ul style="margin-top: auto;">
+        <li>The name of the <code>Fixture</code> class method must match the value of the <code>fixture</code> 
+            attribute on the test method, <i>or</i> the <code class="keyword">@Fixture</code> annotation must
+            have a <code>name</code> attribute which matches the value of the <code>fixture</code> 
+            attribute on the test method.</li>
+        <li>Execution of a Fixture method will stop when an assertion fails or a <code>Progress.Lang.Error</code>
+            is thrown.</li>
+        <li>There are no special naming requirements for Fixture methods.</li>
+        <li>Fixture methods must be <code class="keyword">PUBLIC</code></li>
+        <li>Fixture methods must accept no parameters.</li>
+        <li>Fixture methods can be <code class="keyword">STATIC</code>.</li>
+        <li>Fixture methods can be used by more than one test method.</li>
+        <li>A transaction is created before the records provided in the fixture are loaded, and is rolled-back 
+            after the test method returns.</li>
+    </ul>
+    <p>
+        <br />
+        3. Run the test case as per normal.</p>
+    <p>
+    <a name="methods"></a>
+    <h2>Name Attribute</h2>
+    <p>
+        Each method annotated with <code>@Fixture</code> can specify a name attribute which is used
+        when searching for a Fixture method, instead of the method name.
+    </p>
+    <p>
+        <b>Syntax:</b></p>
+    <p class="syntax">
+        <pre>   @Fixture[(name="<i>FixtureName</i>")].</pre></p>
+    <p class="syntax">
+        <i><b>FixtureName</b></i><br />
+        &nbsp;&nbsp;&nbsp; The Name of the Fixture. This name can then be specified by
+        a test method as its Fixture, in the <code>fixture</code> attribute<br />
+    </p>
+    <p>
+        <b>
+            <br />
+            Example:</b>
+    </p>
+    <pre class="code">   @Test (dataProvider=OrderStatusFixture). 
+   <span class="keyword">METHOD PUBLIC VOID</span> AcceptStatusChange(): 
+     <span class="keyword">DEFINE VARIABLE</span> result <span class="keyword">AS LOGICAL NO-UNDO.</span>
+     <span class="keyword">FIND FIRST</span> Order 
+          <span class="keyword">WHERE</span> Order.Status = "NEW" <span class="keyword">NO-LOCK NO-ERROR</span>.
+     Order:OpenOrder(Order.OrderNo).
+     result = Order:ChangeStatus(INPUT "ACCEPTED"). 
+     Assert:AreEqual(result,<span class="literal">TRUE</span>).
+   <span class="keyword">END METHOD</span>. 
+   
+   @Fixture (name=OrderStatusFixture). 
+   <span class="keyword">METHOD PUBLIC </span>Fixture myFixture(): 
+     <span class="keyword">DEFINE VARIABLE</span> fixture <span class="keyword">AS</span> Fixture <span class="keyword">NO-UNDO</span>.
+     fixture = <span class="keyword">NEW</span> Fixture().
+     fixture:FromJSON(<span class="literal">"~{ ~"Order~": ["
+                      + "~{ ~"OrderNo~": ~"10000~", ~"CustomerNo~": 99000, ~"Status~": ~"COMPLETED~"},"
+                      + "~{ ~"OrderNo~": ~"10001~", ~"CustomerNo~": 99001, ~"Status~": ~"CANCELLED~"},"
+                      + "~{ ~"OrderNo~": ~"10002~", ~"CustomerNo~": 99002, ~"Status~": ~"COMPLETED~"},"
+                      + "~{ ~"OrderNo~": ~"10003~", ~"CustomerNo~": 99000, ~"Status~": ~"NEW~"},"
+                      + "~{ ~"OrderNo~": ~"10004~", ~"CustomerNo~": 99003, ~"Status~": ~"ACCEPTED~"},"
+                      + "~{ ~"OrderNo~": ~"10005~", ~"CustomerNo~": 99004, ~"Status~": ~"PAID~"},"
+                      + "]}"</span>).
+     <span class="keyword">RETURN</span> fixture.
+   <span class="keyword">END METHOD</span>.</pre>
+   <h2>Fixture Methods</h2>
+   <p>The Fixture class provides a range of methods for loading data into the Fixture.</p>
+   <p>Each successive call to one of these methods defines a range of data to be loaded. When
+      the records are loaded, they are done so in the order that they are specified to the Fixture
+      object.</p>
+   <p><b>METHOD PUBLIC LOGICAL FromJSON(INPUT json AS LONGCHAR)</b></p>
+   <p>This method is used to load data from JSON text stored in a <span class="keyword">LONGCHAR</span>.</p>
+   <p class="important">
+        <b>
+            <br />
+            Notes:</b></p>
+    <ul style="margin-top: auto;">
+        <li>The structure of the JSON data should match that which is accepted by an OpenEdge <span class="keyword">DATASET</span>
+            when using the <span class="keyword">READ-JSON</span> method.</li>
+        <li>The method will return <span class="keyword">TRUE</span> if the data was successfully loaded.</li>
+        <li>Only data in the top-level objects in the JSON data will be loaded. Child objects are ignored.</li>
+    </ul>
+   <p><b>METHOD PUBLIC LOGICAL FromJSONFile(INPUT path AS CHARACTER):</b></p>
+   <p>This method is used to load data from JSON text stored in a file. The file path should be provided as the 
+      <span class="keyword">INPUT</span> parameter.</p>
+   <p class="important">
+        <b>
+            <br />
+            Notes:</b></p>
+    <ul style="margin-top: auto;">
+        <li>The structure of the JSON data in the file should match that which is accepted by an OpenEdge 
+            <span class="keyword">DATASET</span> when using the <span class="keyword">READ-JSON</span> method.</li>
+        <li>The method will return <span class="keyword">TRUE</span> if the data was successfully loaded.</li>
+        <li>Only data in the top-level objects in the JSON data will be loaded. Child objects are ignored.</li>
+    </ul>
+   <p><b>METHOD PUBLIC LOGICAL FromXML(INPUT xml AS LONGCHAR)</b></p>
+   <p>This method is used to load data from XML data stored in a <span class="keyword">LONGCHAR</span>.</p>
+   <p class="important">
+        <b>
+            <br />
+            Notes:</b></p>
+    <ul style="margin-top: auto;">
+        <li>The structure of the XML data should match that which is accepted by an OpenEdge <span class="keyword">DATASET</span>
+            when using the <span class="keyword">READ-XML</span> method.</li>
+        <li>The method will return <span class="keyword">TRUE</span> if the data was successfully loaded.</li>
+        <li>It is advised to specify the XML Schema in the XML data in order for data types to be correctly interpreted.</li>
+        <li>Only data in the top-level objects in the XML data will be loaded. Child objects are ignored.</li>
+    </ul>
+   <p><b>METHOD PUBLIC LOGICAL FromXMLFile(INPUT path AS CHARACTER):</b></p>
+   <p>This method is used to load data from XML data stored in a file. The file path should be provided as the 
+      <span class="keyword">INPUT</span> parameter.</p>
+   <p class="important">
+        <b>
+            <br />
+            Notes:</b></p>
+    <ul style="margin-top: auto;">
+        <li>The structure of the XML data in the file should match that which is accepted by an OpenEdge 
+            <span class="keyword">DATASET</span> when using the <span class="keyword">READ-XML</span> method.</li>
+        <li>The method will return <span class="keyword">TRUE</span> if the data was successfully loaded.</li>
+        <li>It is advised to specify the XML Schema in the XML data in order for data types to be correctly interpreted.</li>
+        <li>Only data in the top-level objects in the XML data will be loaded. Child objects are ignored.</li>
+    </ul>
+   <p><b>METHOD PUBLIC LOGICAL FromTempTable(INPUT ttSrc AS HANDLE):</b></p>
+   <p>This method is used to load data from an existing temp-table, via the provided <span class="keyword">HANDLE INPUT</span> parameter.</p>
+   <p class="important">
+        <b>
+            <br />
+            Notes:</b></p>
+    <ul style="margin-top: auto;">
+        <li>The entire data and metaschema of the temp-table are copied.</li>
+        <li>Data is copied in EMPTY mode</li>
+        <li>The data and metaschema of the provided source temp-table are not affected.</li>
+        <li>The method will return <span class="keyword">TRUE</span> if the data was successfully loaded.</li>
+    </ul>
+    <p><b>METHOD PUBLIC LOGICAL FromDataSet(INPUT dsSrc AS HANDLE):</b></p>
+   <p>This method is used to load data from an existing DataSet, via the provided <span class="keyword">HANDLE INPUT</span> parameter.</p>
+   <p class="important">
+        <b>
+            <br />
+            Notes:</b></p>
+    <ul style="margin-top: auto;">
+        <li>The entire data and metaschema of the temp-table are copied.</li>
+        <li>Data is copied in EMPTY mode</li>
+        <li>The method will return <span class="keyword">TRUE</span> if the data was successfully loaded.</li>
+    </ul>
+    <div class="footer">
+        Cameron Wills, 2011.</div>
+</body>
+</html>

--- a/doc/index.html
+++ b/doc/index.html
@@ -17,6 +17,7 @@
                     <li><a href="runningtests.html">Running a Test</a></li>
                     <li><a href="reportingtests.html">Reporting Test Results</a></li>
                     <li><a href="dataprovider.html">DataProviders</a></li>
+                    <li><a href="fixtures.html">Fixtures</a></li>
                     <li><a href="license.html">License</a></li>
                     <li><a href="changelog.html">Change Log</a></li>
                 </ul>

--- a/doc/installation.html
+++ b/doc/installation.html
@@ -17,6 +17,7 @@
                     <li><a href="runningtests.html">Running a Test</a></li>
                     <li><a href="reportingtests.html">Reporting Test Results</a></li>
                     <li><a href="dataprovider.html">DataProviders</a></li>
+                    <li><a href="fixtures.html">Fixtures</a></li>
                     <li><a href="license.html">License</a></li>
                     <li><a href="changelog.html">Change Log</a></li>
                 </ul>

--- a/doc/reportingtests.html
+++ b/doc/reportingtests.html
@@ -17,6 +17,7 @@
                     <li><a href="runningtests.html">Running a Test</a></li>
                     <li>Reporting Test Results</li>
                     <li><a href="dataprovider.html">DataProviders</a></li>
+                    <li><a href="fixtures.html">Fixtures</a></li>
                     <li><a href="license.html">License</a></li>
                     <li><a href="changelog.html">Change Log</a></li>
                 </ul>

--- a/doc/runningtests.html
+++ b/doc/runningtests.html
@@ -17,6 +17,7 @@
                     <li>Running a Test</li>
                     <li><a href="reportingtests.html">Reporting Test Results</a></li>
                     <li><a href="dataprovider.html">DataProviders</a></li>
+                    <li><a href="fixtures.html">Fixtures</a></li>
                     <li><a href="license.html">License</a></li>
                     <li><a href="changelog.html">Change Log</a></li>
                 </ul>

--- a/doc/testcase.html
+++ b/doc/testcase.html
@@ -17,6 +17,7 @@
                     <li><a href="runningtests.html">Running a Test</a></li>
                     <li><a href="reportingtests.html">Reporting Test Results</a></li>
                     <li><a href="dataprovider.html">DataProviders</a></li>
+                    <li><a href="fixtures.html">Fixtures</a></li>
                     <li><a href="license.html">License</a></li>
                     <li><a href="changelog.html">Change Log</a></li>
                 </ul>

--- a/doc/testsuite.html
+++ b/doc/testsuite.html
@@ -17,6 +17,7 @@
                     <li><a href="runningtests.html">Running a Test</a></li>
                     <li><a href="reportingtests.html">Reporting Test Results</a></li>
                     <li><a href="dataprovider.html">DataProviders</a></li>
+                    <li><a href="fixtures.html">Fixtures</a></li>
                     <li><a href="license.html">License</a></li>
                     <li><a href="changelog.html">Change Log</a></li>
                 </ul>

--- a/src/OEUnit/Data/Fixture.cls
+++ b/src/OEUnit/Data/Fixture.cls
@@ -1,0 +1,173 @@
+/*------------------------------------------------------------------------------
+  File        :   Fixture.cls
+  Package     :   OEUnit.Data
+  Description :   Stores and uses data provided in associated methods when
+                  calling a test case to pre-load database tables for a test.
+------------------------------------------------------------------------------*/
+USING Progress.Lang.*.
+USING OEUnit.Data.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEUnit.Data.Fixture: 
+	
+  DEFINE PROTECTED VARIABLE dsData AS HANDLE NO-UNDO.
+  
+  /*----------------------------------------------------------------------------
+    Read-only Property that returns the number of top level buffers in dataset
+  ----------------------------------------------------------------------------*/
+  DEFINE PUBLIC PROPERTY TableCount AS INTEGER NO-UNDO
+    GET ():
+      IF VALID-HANDLE(dsData) THEN RETURN dsData:NUM-TOP-BUFFERS.
+      ELSE RETURN 0.
+    END GET.
+
+  CONSTRUCTOR PUBLIC Fixture():
+	SUPER ().
+  END CONSTRUCTOR.
+
+  DESTRUCTOR PUBLIC Fixture():
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+  END DESTRUCTOR.
+
+  /*----------------------------------------------------------------------------
+    Import fixture data from dataset encoded in JSON via parameter
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromJSON(INPUT json AS LONGCHAR):
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    res = dsData:READ-JSON("LONGCHAR", json, "EMPTY").
+    RETURN res.
+  END METHOD.
+
+  /*----------------------------------------------------------------------------
+    Import fixture data from data encoded in JSON in given file
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromJSONFile(INPUT path AS CHARACTER):
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    res = dsData:READ-JSON("FILE", path, "EMPTY").
+    RETURN res.
+  END METHOD.
+
+  /*----------------------------------------------------------------------------
+    Import fixture data from dataset encoded in XML via parameter
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromXML(INPUT xml AS LONGCHAR):
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    res = dsData:READ-XML("LONGCHAR", xml, "EMPTY", ?, ?).
+    RETURN res.
+  END METHOD.
+
+  /*----------------------------------------------------------------------------
+    Import fixture data from data encoded in XML in given file
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromXMLFile(INPUT path AS CHARACTER):
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    res = dsData:READ-XML("FILE", path, "EMPTY", ?, ?).
+    RETURN res.
+  END METHOD.
+  
+  /*----------------------------------------------------------------------------
+    Import fixture data by copying from an existing dataset
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromDataSet(INPUT dsSrc AS HANDLE):
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    res = dsData:COPY-DATASET(dsSrc).
+    RETURN res.
+  END METHOD.
+  
+  /*----------------------------------------------------------------------------
+    Import fixture data by copying from a temp-table
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromTempTable(INPUT ttSrc AS HANDLE):
+    DEFINE VARIABLE res       AS LOGICAL NO-UNDO.
+    DEFINE VARIABLE ttSrcCpy  AS HANDLE NO-UNDO.
+    DEFINE VARIABLE ttData    AS HANDLE NO-UNDO.
+    DEFINE VARIABLE ttDataBuf AS HANDLE NO-UNDO.
+    DEFINE VARIABLE hSource   AS HANDLE NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    IF NOT VALID-HANDLE(dsData) THEN RETURN FALSE.
+    CREATE TEMP-TABLE ttData.
+    res = ttData:COPY-TEMP-TABLE(ttSrc,FALSE,FALSE,FALSE,"").
+    IF res = FALSE THEN
+    DO:
+      IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+      IF VALID-HANDLE(ttData) THEN DELETE OBJECT ttData.
+      RETURN res.
+    END.
+    CREATE TEMP-TABLE ttSrcCpy.
+    res = ttSrcCpy:COPY-TEMP-TABLE(ttSrc,FALSE,FALSE,FALSE,"").
+    IF res = FALSE THEN
+    DO:
+      IF VALID-HANDLE(dsData)   THEN DELETE OBJECT dsData.
+      IF VALID-HANDLE(ttData)   THEN DELETE OBJECT ttData.
+      IF VALID-HANDLE(ttSrcCpy) THEN DELETE OBJECT ttSrcCpy.
+      RETURN res.
+    END.
+    ttDataBuf = ttData:DEFAULT-BUFFER-HANDLE.
+    dsData:ADD-BUFFER(ttDataBuf).
+    CREATE DATA-SOURCE hSource.
+    IF NOT VALID-HANDLE(hSource) THEN
+    DO:
+      IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+      DELETE OBJECT hSource.
+    END.
+    hSource:ADD-SOURCE-BUFFER(ttSrcCpy:DEFAULT-BUFFER-HANDLE,?).
+    ttDataBuf:ATTACH-DATA-SOURCE(hSource).
+    dsData:FILL().
+    RETURN res.
+  END METHOD.
+  
+  /*----------------------------------------------------------------------------
+    Create data in the attached databases, based on data in dataset tables.
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL CreateData():
+    DEFINE VARIABLE hBuffer  AS HANDLE  NO-UNDO.
+    DEFINE VARIABLE hQuery   AS HANDLE  NO-UNDO.
+    DEFINE VARIABLE hQBuffer AS HANDLE  NO-UNDO.
+    DEFINE VARIABLE hRBuffer AS HANDLE  NO-UNDO.
+    DEFINE VARIABLE iCount   AS INTEGER NO-UNDO.
+    
+    /* Ensure that any errors are thrown properly */
+    DO ON ERROR UNDO, THROW:
+      IF NOT VALID-HANDLE(dsData) THEN RETURN FALSE.
+      DO iCount = 1 TO dsData:NUM-TOP-BUFFERS
+        ON ERROR UNDO, THROW:
+        hBuffer = dsData:GET-TOP-BUFFER(iCount).
+        IF NOT VALID-HANDLE(hBuffer) THEN RETURN ERROR NEW FixtureError("Failed to fetch buffer from DataSet").
+        IF VALID-HANDLE(hQuery) THEN DELETE OBJECT hQuery.
+        IF VALID-HANDLE(hQBuffer) THEN DELETE OBJECT hQBuffer.
+        CREATE BUFFER hQBuffer FOR TABLE hBuffer.
+        CREATE BUFFER hRBuffer FOR TABLE hBuffer:NAME NO-ERROR.
+        IF ERROR-STATUS:ERROR THEN RETURN ERROR NEW FixtureError(SUBSTITUTE("Could not create buffer for destination table &1.", hBuffer:NAME)).
+        CREATE QUERY hQuery.
+        hQuery:SET-BUFFERS(hQBuffer). /* NOTE: Because this is taken from Dataset, names of tables can overlap and doesn't cause a problem */
+        IF(hQuery:QUERY-PREPARE("FOR EACH " + hBuffer:NAME + " NO-LOCK:") = FALSE) THEN
+          RETURN ERROR NEW FixtureError(SUBSTITUTE("Could not query data in source &1.", hBuffer:NAME)).
+        hQuery:QUERY-OPEN().
+        hQuery:GET-FIRST(NO-LOCK).
+        DO WHILE NOT hQuery:QUERY-OFF-END
+          ON ERROR UNDO, THROW:
+            hRBuffer:BUFFER-CREATE().
+            hRBuffer:BUFFER-COPY(hQBuffer).
+            hRBuffer:BUFFER-RELEASE().
+            hQuery:GET-NEXT().
+        END.
+        IF VALID-HANDLE(hRBuffer) THEN DELETE OBJECT hRBuffer.
+        IF VALID-HANDLE(hQBuffer) THEN DELETE OBJECT hQBuffer.
+        IF VALID-HANDLE(hQuery)   THEN DELETE OBJECT hQuery.
+      END.
+    END.
+  END METHOD.
+
+END CLASS.

--- a/src/OEUnit/Data/Fixture.cls
+++ b/src/OEUnit/Data/Fixture.cls
@@ -6,38 +6,71 @@
 ------------------------------------------------------------------------------*/
 USING Progress.Lang.*.
 USING OEUnit.Data.*.
+USING OEUnit.Util.*.
 
 ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
 CLASS OEUnit.Data.Fixture: 
 	
   DEFINE PROTECTED VARIABLE dsData AS HANDLE NO-UNDO.
+  DEFINE PROTECTED VARIABLE Fixtures AS List NO-UNDO. 
   
   /*----------------------------------------------------------------------------
     Read-only Property that returns the number of top level buffers in dataset
   ----------------------------------------------------------------------------*/
   DEFINE PUBLIC PROPERTY TableCount AS INTEGER NO-UNDO
     GET ():
+      DEFINE VARIABLE tCount AS INTEGER NO-UNDO INITIAL 0.
+      DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+      DEFINE VARIABLE fix AS FixtureDataSet NO-UNDO.
+      IF VALID-OBJECT(Fixtures) THEN
+      DO:
+          res = Fixtures:MoveFirst().
+          DO WHILE res = TRUE
+            ON ERROR UNDO, THROW:
+            fix = CAST(Fixtures:CURRENT, "OEUnit.Data.FixtureDataSet").
+            tCount = tCount + fix:TableCount.
+            res = Fixtures:MoveNext().
+          END.
+          RETURN tCount.
+      END.
       IF VALID-HANDLE(dsData) THEN RETURN dsData:NUM-TOP-BUFFERS.
       ELSE RETURN 0.
     END GET.
 
+  /*----------------------------------------------------------------------------
+    The number of elements in the list  
+  ----------------------------------------------------------------------------*/  
+  DEFINE PUBLIC PROPERTY Size AS INTEGER NO-UNDO INIT 0
+    GET ():
+      IF VALID-OBJECT(Fixtures) THEN RETURN Fixtures:Size.
+      ELSE RETURN 0.
+    END GET.
+    PRIVATE SET.
+
   CONSTRUCTOR PUBLIC Fixture():
 	SUPER ().
+	Fixtures = NEW List(TRUE). /* TRUE => destory list objects on destruction */
   END CONSTRUCTOR.
 
   DESTRUCTOR PUBLIC Fixture():
     IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    IF VALID-OBJECT(Fixtures) THEN DELETE OBJECT Fixtures.
   END DESTRUCTOR.
 
   /*----------------------------------------------------------------------------
     Import fixture data from dataset encoded in JSON via parameter
   ----------------------------------------------------------------------------*/
   METHOD PUBLIC LOGICAL FromJSON(INPUT json AS LONGCHAR):
+    DEFINE VARIABLE fix AS FixtureDataSet NO-UNDO.
     DEFINE VARIABLE res AS LOGICAL NO-UNDO.
-    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
-    CREATE DATASET dsData.
-    res = dsData:READ-JSON("LONGCHAR", json, "EMPTY").
+    fix = NEW FixtureDataSet().
+    res = fix:FromJSON(INPUT json).
+    IF res = TRUE THEN
+      Fixtures:Add(fix).
+    ELSE
+      IF VALID-OBJECT(fix) THEN
+        DELETE OBJECT fix.
     RETURN res.
   END METHOD.
 
@@ -45,10 +78,15 @@ CLASS OEUnit.Data.Fixture:
     Import fixture data from data encoded in JSON in given file
   ----------------------------------------------------------------------------*/
   METHOD PUBLIC LOGICAL FromJSONFile(INPUT path AS CHARACTER):
+    DEFINE VARIABLE fix AS FixtureDataSet NO-UNDO.
     DEFINE VARIABLE res AS LOGICAL NO-UNDO.
-    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
-    CREATE DATASET dsData.
-    res = dsData:READ-JSON("FILE", path, "EMPTY").
+    fix = NEW FixtureDataSet().
+    res = fix:FromJSONFile(INPUT path).
+    IF res = TRUE THEN
+      Fixtures:Add(fix).
+    ELSE
+      IF VALID-OBJECT(fix) THEN
+        DELETE OBJECT fix.
     RETURN res.
   END METHOD.
 
@@ -56,10 +94,15 @@ CLASS OEUnit.Data.Fixture:
     Import fixture data from dataset encoded in XML via parameter
   ----------------------------------------------------------------------------*/
   METHOD PUBLIC LOGICAL FromXML(INPUT xml AS LONGCHAR):
+    DEFINE VARIABLE fix AS FixtureDataSet NO-UNDO.
     DEFINE VARIABLE res AS LOGICAL NO-UNDO.
-    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
-    CREATE DATASET dsData.
-    res = dsData:READ-XML("LONGCHAR", xml, "EMPTY", ?, ?).
+    fix = NEW FixtureDataSet().
+    res = fix:FromXML(INPUT xml).
+    IF res = TRUE THEN
+      Fixtures:Add(fix).
+    ELSE
+      IF VALID-OBJECT(fix) THEN
+        DELETE OBJECT fix.
     RETURN res.
   END METHOD.
 
@@ -67,10 +110,15 @@ CLASS OEUnit.Data.Fixture:
     Import fixture data from data encoded in XML in given file
   ----------------------------------------------------------------------------*/
   METHOD PUBLIC LOGICAL FromXMLFile(INPUT path AS CHARACTER):
+    DEFINE VARIABLE fix AS FixtureDataSet NO-UNDO.
     DEFINE VARIABLE res AS LOGICAL NO-UNDO.
-    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
-    CREATE DATASET dsData.
-    res = dsData:READ-XML("FILE", path, "EMPTY", ?, ?).
+    fix = NEW FixtureDataSet().
+    res = fix:FromXMLFile(INPUT path).
+    IF res = TRUE THEN
+      Fixtures:Add(fix).
+    ELSE
+      IF VALID-OBJECT(fix) THEN
+        DELETE OBJECT fix.
     RETURN res.
   END METHOD.
   
@@ -78,10 +126,15 @@ CLASS OEUnit.Data.Fixture:
     Import fixture data by copying from an existing dataset
   ----------------------------------------------------------------------------*/
   METHOD PUBLIC LOGICAL FromDataSet(INPUT dsSrc AS HANDLE):
+    DEFINE VARIABLE fix AS FixtureDataSet NO-UNDO.
     DEFINE VARIABLE res AS LOGICAL NO-UNDO.
-    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
-    CREATE DATASET dsData.
-    res = dsData:COPY-DATASET(dsSrc).
+    fix = NEW FixtureDataSet().
+    res = fix:FromDataSet(INPUT dsSrc).
+    IF res = TRUE THEN
+      Fixtures:Add(fix).
+    ELSE
+      IF VALID-OBJECT(fix) THEN
+        DELETE OBJECT fix.
     RETURN res.
   END METHOD.
   
@@ -89,42 +142,15 @@ CLASS OEUnit.Data.Fixture:
     Import fixture data by copying from a temp-table
   ----------------------------------------------------------------------------*/
   METHOD PUBLIC LOGICAL FromTempTable(INPUT ttSrc AS HANDLE):
-    DEFINE VARIABLE res       AS LOGICAL NO-UNDO.
-    DEFINE VARIABLE ttSrcCpy  AS HANDLE NO-UNDO.
-    DEFINE VARIABLE ttData    AS HANDLE NO-UNDO.
-    DEFINE VARIABLE ttDataBuf AS HANDLE NO-UNDO.
-    DEFINE VARIABLE hSource   AS HANDLE NO-UNDO.
-    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
-    CREATE DATASET dsData.
-    IF NOT VALID-HANDLE(dsData) THEN RETURN FALSE.
-    CREATE TEMP-TABLE ttData.
-    res = ttData:COPY-TEMP-TABLE(ttSrc,FALSE,FALSE,FALSE,"").
-    IF res = FALSE THEN
-    DO:
-      IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
-      IF VALID-HANDLE(ttData) THEN DELETE OBJECT ttData.
-      RETURN res.
-    END.
-    CREATE TEMP-TABLE ttSrcCpy.
-    res = ttSrcCpy:COPY-TEMP-TABLE(ttSrc,FALSE,FALSE,FALSE,"").
-    IF res = FALSE THEN
-    DO:
-      IF VALID-HANDLE(dsData)   THEN DELETE OBJECT dsData.
-      IF VALID-HANDLE(ttData)   THEN DELETE OBJECT ttData.
-      IF VALID-HANDLE(ttSrcCpy) THEN DELETE OBJECT ttSrcCpy.
-      RETURN res.
-    END.
-    ttDataBuf = ttData:DEFAULT-BUFFER-HANDLE.
-    dsData:ADD-BUFFER(ttDataBuf).
-    CREATE DATA-SOURCE hSource.
-    IF NOT VALID-HANDLE(hSource) THEN
-    DO:
-      IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
-      DELETE OBJECT hSource.
-    END.
-    hSource:ADD-SOURCE-BUFFER(ttSrcCpy:DEFAULT-BUFFER-HANDLE,?).
-    ttDataBuf:ATTACH-DATA-SOURCE(hSource).
-    dsData:FILL().
+    DEFINE VARIABLE fix AS FixtureDataSet NO-UNDO.
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    fix = NEW FixtureDataSet().
+    res = fix:FromTempTable(INPUT ttSrc).
+    IF res = TRUE THEN
+      Fixtures:Add(fix).
+    ELSE
+      IF VALID-OBJECT(fix) THEN
+        DELETE OBJECT fix.
     RETURN res.
   END METHOD.
   
@@ -132,41 +158,16 @@ CLASS OEUnit.Data.Fixture:
     Create data in the attached databases, based on data in dataset tables.
   ----------------------------------------------------------------------------*/
   METHOD PUBLIC LOGICAL CreateData():
-    DEFINE VARIABLE hBuffer  AS HANDLE  NO-UNDO.
-    DEFINE VARIABLE hQuery   AS HANDLE  NO-UNDO.
-    DEFINE VARIABLE hQBuffer AS HANDLE  NO-UNDO.
-    DEFINE VARIABLE hRBuffer AS HANDLE  NO-UNDO.
-    DEFINE VARIABLE iCount   AS INTEGER NO-UNDO.
-    
-    /* Ensure that any errors are thrown properly */
-    DO ON ERROR UNDO, THROW:
-      IF NOT VALID-HANDLE(dsData) THEN RETURN FALSE.
-      DO iCount = 1 TO dsData:NUM-TOP-BUFFERS
-        ON ERROR UNDO, THROW:
-        hBuffer = dsData:GET-TOP-BUFFER(iCount).
-        IF NOT VALID-HANDLE(hBuffer) THEN RETURN ERROR NEW FixtureError("Failed to fetch buffer from DataSet").
-        IF VALID-HANDLE(hQuery) THEN DELETE OBJECT hQuery.
-        IF VALID-HANDLE(hQBuffer) THEN DELETE OBJECT hQBuffer.
-        CREATE BUFFER hQBuffer FOR TABLE hBuffer.
-        CREATE BUFFER hRBuffer FOR TABLE hBuffer:NAME NO-ERROR.
-        IF ERROR-STATUS:ERROR THEN RETURN ERROR NEW FixtureError(SUBSTITUTE("Could not create buffer for destination table &1.", hBuffer:NAME)).
-        CREATE QUERY hQuery.
-        hQuery:SET-BUFFERS(hQBuffer). /* NOTE: Because this is taken from Dataset, names of tables can overlap and doesn't cause a problem */
-        IF(hQuery:QUERY-PREPARE("FOR EACH " + hBuffer:NAME + " NO-LOCK:") = FALSE) THEN
-          RETURN ERROR NEW FixtureError(SUBSTITUTE("Could not query data in source &1.", hBuffer:NAME)).
-        hQuery:QUERY-OPEN().
-        hQuery:GET-FIRST(NO-LOCK).
-        DO WHILE NOT hQuery:QUERY-OFF-END
-          ON ERROR UNDO, THROW:
-            hRBuffer:BUFFER-CREATE().
-            hRBuffer:BUFFER-COPY(hQBuffer).
-            hRBuffer:BUFFER-RELEASE().
-            hQuery:GET-NEXT().
-        END.
-        IF VALID-HANDLE(hRBuffer) THEN DELETE OBJECT hRBuffer.
-        IF VALID-HANDLE(hQBuffer) THEN DELETE OBJECT hQBuffer.
-        IF VALID-HANDLE(hQuery)   THEN DELETE OBJECT hQuery.
-      END.
+    DEFINE VARIABLE fix AS FixtureDataSet NO-UNDO.
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF NOT VALID-OBJECT(Fixtures) THEN RETURN FALSE.
+    res = fixtures:MoveFirst().
+    DO WHILE res = TRUE
+      ON ERROR UNDO, THROW:
+      fix = CAST(fixtures:CURRENT, "OEUnit.Data.FixtureDataSet").
+      IF VALID-OBJECT(fix) THEN
+        fix:CreateData().
+      res = fixtures:MoveNext().
     END.
   END METHOD.
 

--- a/src/OEUnit/Data/Fixture.cls
+++ b/src/OEUnit/Data/Fixture.cls
@@ -12,7 +12,6 @@ ROUTINE-LEVEL ON ERROR UNDO, THROW.
 
 CLASS OEUnit.Data.Fixture: 
 	
-  DEFINE PROTECTED VARIABLE dsData AS HANDLE NO-UNDO.
   DEFINE PROTECTED VARIABLE Fixtures AS List NO-UNDO. 
   
   /*----------------------------------------------------------------------------
@@ -34,8 +33,7 @@ CLASS OEUnit.Data.Fixture:
           END.
           RETURN tCount.
       END.
-      IF VALID-HANDLE(dsData) THEN RETURN dsData:NUM-TOP-BUFFERS.
-      ELSE RETURN 0.
+      RETURN 0.
     END GET.
 
   /*----------------------------------------------------------------------------
@@ -54,7 +52,6 @@ CLASS OEUnit.Data.Fixture:
   END CONSTRUCTOR.
 
   DESTRUCTOR PUBLIC Fixture():
-    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
     IF VALID-OBJECT(Fixtures) THEN DELETE OBJECT Fixtures.
   END DESTRUCTOR.
 

--- a/src/OEUnit/Data/FixtureCreateError.cls
+++ b/src/OEUnit/Data/FixtureCreateError.cls
@@ -1,0 +1,18 @@
+/*------------------------------------------------------------------------------
+  File        :   FixtureCreateError.cls
+  Package     :   OEUnit.Data
+  Description :   The exception thrown when Fixture encounters a problem.
+------------------------------------------------------------------------------*/
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEUnit.Data.FixtureCreateError INHERITS Progress.Lang.AppError: 
+
+  /*----------------------------------------------------------------------------
+    Constructor. Accepts an error message.
+  ----------------------------------------------------------------------------*/    
+  CONSTRUCTOR PUBLIC FixtureCreateError(INPUT errorMessage AS CHARACTER):
+    SUPER(SUBSTITUTE("Fixture Error: &1",errorMessage), 0).
+  END CONSTRUCTOR.
+
+END CLASS.

--- a/src/OEUnit/Data/FixtureDataSet.cls
+++ b/src/OEUnit/Data/FixtureDataSet.cls
@@ -90,14 +90,15 @@ CLASS OEUnit.Data.FixtureDataSet:
   ----------------------------------------------------------------------------*/
   METHOD PUBLIC LOGICAL FromTempTable(INPUT ttSrc AS HANDLE):
     DEFINE VARIABLE res       AS LOGICAL NO-UNDO.
-    DEFINE VARIABLE ttSrcCpy  AS HANDLE NO-UNDO.
     DEFINE VARIABLE ttData    AS HANDLE NO-UNDO.
     DEFINE VARIABLE ttDataBuf AS HANDLE NO-UNDO.
-    DEFINE VARIABLE hSource   AS HANDLE NO-UNDO.
     IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
     CREATE DATASET dsData.
     IF NOT VALID-HANDLE(dsData) THEN RETURN FALSE.
     CREATE TEMP-TABLE ttData.
+    /* COPY-TEMP-TABLE will also copy data as well, and hence there
+     * is no need to configure data sources and call DataSet:Fill()
+     */
     res = ttData:COPY-TEMP-TABLE(ttSrc,FALSE,FALSE,FALSE,"").
     IF res = FALSE THEN
     DO:
@@ -105,27 +106,9 @@ CLASS OEUnit.Data.FixtureDataSet:
       IF VALID-HANDLE(ttData) THEN DELETE OBJECT ttData.
       RETURN res.
     END.
-    CREATE TEMP-TABLE ttSrcCpy.
-    res = ttSrcCpy:COPY-TEMP-TABLE(ttSrc,FALSE,FALSE,FALSE,"").
-    IF res = FALSE THEN
-    DO:
-      IF VALID-HANDLE(dsData)   THEN DELETE OBJECT dsData.
-      IF VALID-HANDLE(ttData)   THEN DELETE OBJECT ttData.
-      IF VALID-HANDLE(ttSrcCpy) THEN DELETE OBJECT ttSrcCpy.
-      RETURN res.
-    END.
     ttDataBuf = ttData:DEFAULT-BUFFER-HANDLE.
     dsData:ADD-BUFFER(ttDataBuf).
-    CREATE DATA-SOURCE hSource.
-    IF NOT VALID-HANDLE(hSource) THEN
-    DO:
-      IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
-      DELETE OBJECT hSource.
-    END.
-    hSource:ADD-SOURCE-BUFFER(ttSrcCpy:DEFAULT-BUFFER-HANDLE,?).
-    ttDataBuf:ATTACH-DATA-SOURCE(hSource).
-    dsData:FILL().
-    RETURN res.
+    RETURN TRUE.
   END METHOD.
   
   /*----------------------------------------------------------------------------
@@ -163,6 +146,7 @@ CLASS OEUnit.Data.FixtureDataSet:
             hRBuffer:BUFFER-RELEASE().
             hQuery:GET-NEXT().
         END.
+        hQuery:QUERY-CLOSE().
         IF VALID-HANDLE(hRBuffer) THEN DELETE OBJECT hRBuffer.
         IF VALID-HANDLE(hQBuffer) THEN DELETE OBJECT hQBuffer.
         IF VALID-HANDLE(hQuery)   THEN DELETE OBJECT hQuery.

--- a/src/OEUnit/Data/FixtureDataSet.cls
+++ b/src/OEUnit/Data/FixtureDataSet.cls
@@ -1,0 +1,173 @@
+/*------------------------------------------------------------------------------
+  File        :   FixtureDataSet.cls
+  Package     :   OEUnit.Data
+  Description :   Stores and uses data provided in associated methods when
+                  calling a test case to pre-load database tables for a test.
+------------------------------------------------------------------------------*/
+USING Progress.Lang.*.
+USING OEUnit.Data.*.
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEUnit.Data.FixtureDataSet: 
+	
+  DEFINE PROTECTED VARIABLE dsData AS HANDLE NO-UNDO.
+  
+  /*----------------------------------------------------------------------------
+    Read-only Property that returns the number of top level buffers in dataset
+  ----------------------------------------------------------------------------*/
+  DEFINE PUBLIC PROPERTY TableCount AS INTEGER NO-UNDO
+    GET ():
+      IF VALID-HANDLE(dsData) THEN RETURN dsData:NUM-TOP-BUFFERS.
+      ELSE RETURN 0.
+    END GET.
+
+  CONSTRUCTOR PUBLIC FixtureDataSet():
+	SUPER ().
+  END CONSTRUCTOR.
+
+  DESTRUCTOR PUBLIC FixtureDataSet():
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+  END DESTRUCTOR.
+
+  /*----------------------------------------------------------------------------
+    Import fixture data from dataset encoded in JSON via parameter
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromJSON(INPUT json AS LONGCHAR):
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    res = dsData:READ-JSON("LONGCHAR", json, "EMPTY").
+    RETURN res.
+  END METHOD.
+
+  /*----------------------------------------------------------------------------
+    Import fixture data from data encoded in JSON in given file
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromJSONFile(INPUT path AS CHARACTER):
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    res = dsData:READ-JSON("FILE", path, "EMPTY").
+    RETURN res.
+  END METHOD.
+
+  /*----------------------------------------------------------------------------
+    Import fixture data from dataset encoded in XML via parameter
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromXML(INPUT xml AS LONGCHAR):
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    res = dsData:READ-XML("LONGCHAR", xml, "EMPTY", ?, ?).
+    RETURN res.
+  END METHOD.
+
+  /*----------------------------------------------------------------------------
+    Import fixture data from data encoded in XML in given file
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromXMLFile(INPUT path AS CHARACTER):
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    res = dsData:READ-XML("FILE", path, "EMPTY", ?, ?).
+    RETURN res.
+  END METHOD.
+  
+  /*----------------------------------------------------------------------------
+    Import fixture data by copying from an existing dataset
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromDataSet(INPUT dsSrc AS HANDLE):
+    DEFINE VARIABLE res AS LOGICAL NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    res = dsData:COPY-DATASET(dsSrc).
+    RETURN res.
+  END METHOD.
+  
+  /*----------------------------------------------------------------------------
+    Import fixture data by copying from a temp-table
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL FromTempTable(INPUT ttSrc AS HANDLE):
+    DEFINE VARIABLE res       AS LOGICAL NO-UNDO.
+    DEFINE VARIABLE ttSrcCpy  AS HANDLE NO-UNDO.
+    DEFINE VARIABLE ttData    AS HANDLE NO-UNDO.
+    DEFINE VARIABLE ttDataBuf AS HANDLE NO-UNDO.
+    DEFINE VARIABLE hSource   AS HANDLE NO-UNDO.
+    IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+    CREATE DATASET dsData.
+    IF NOT VALID-HANDLE(dsData) THEN RETURN FALSE.
+    CREATE TEMP-TABLE ttData.
+    res = ttData:COPY-TEMP-TABLE(ttSrc,FALSE,FALSE,FALSE,"").
+    IF res = FALSE THEN
+    DO:
+      IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+      IF VALID-HANDLE(ttData) THEN DELETE OBJECT ttData.
+      RETURN res.
+    END.
+    CREATE TEMP-TABLE ttSrcCpy.
+    res = ttSrcCpy:COPY-TEMP-TABLE(ttSrc,FALSE,FALSE,FALSE,"").
+    IF res = FALSE THEN
+    DO:
+      IF VALID-HANDLE(dsData)   THEN DELETE OBJECT dsData.
+      IF VALID-HANDLE(ttData)   THEN DELETE OBJECT ttData.
+      IF VALID-HANDLE(ttSrcCpy) THEN DELETE OBJECT ttSrcCpy.
+      RETURN res.
+    END.
+    ttDataBuf = ttData:DEFAULT-BUFFER-HANDLE.
+    dsData:ADD-BUFFER(ttDataBuf).
+    CREATE DATA-SOURCE hSource.
+    IF NOT VALID-HANDLE(hSource) THEN
+    DO:
+      IF VALID-HANDLE(dsData) THEN DELETE OBJECT dsData.
+      DELETE OBJECT hSource.
+    END.
+    hSource:ADD-SOURCE-BUFFER(ttSrcCpy:DEFAULT-BUFFER-HANDLE,?).
+    ttDataBuf:ATTACH-DATA-SOURCE(hSource).
+    dsData:FILL().
+    RETURN res.
+  END METHOD.
+  
+  /*----------------------------------------------------------------------------
+    Create data in the attached databases, based on data in dataset tables.
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL CreateData():
+    DEFINE VARIABLE hBuffer  AS HANDLE  NO-UNDO.
+    DEFINE VARIABLE hQuery   AS HANDLE  NO-UNDO.
+    DEFINE VARIABLE hQBuffer AS HANDLE  NO-UNDO.
+    DEFINE VARIABLE hRBuffer AS HANDLE  NO-UNDO.
+    DEFINE VARIABLE iCount   AS INTEGER NO-UNDO.
+    
+    /* Ensure that any errors are thrown properly */
+    DO ON ERROR UNDO, THROW:
+      IF NOT VALID-HANDLE(dsData) THEN RETURN FALSE.
+      DO iCount = 1 TO dsData:NUM-TOP-BUFFERS
+        ON ERROR UNDO, THROW:
+        hBuffer = dsData:GET-TOP-BUFFER(iCount).
+        IF NOT VALID-HANDLE(hBuffer) THEN RETURN ERROR NEW FixtureError("Failed to fetch buffer from DataSet").
+        IF VALID-HANDLE(hQuery) THEN DELETE OBJECT hQuery.
+        IF VALID-HANDLE(hQBuffer) THEN DELETE OBJECT hQBuffer.
+        CREATE BUFFER hQBuffer FOR TABLE hBuffer.
+        CREATE BUFFER hRBuffer FOR TABLE hBuffer:NAME NO-ERROR.
+        IF ERROR-STATUS:ERROR THEN RETURN ERROR NEW FixtureError(SUBSTITUTE("Could not create buffer for destination table &1.", hBuffer:NAME)).
+        CREATE QUERY hQuery.
+        hQuery:SET-BUFFERS(hQBuffer). /* NOTE: Because this is taken from Dataset, names of tables can overlap and doesn't cause a problem */
+        IF(hQuery:QUERY-PREPARE("FOR EACH " + hBuffer:NAME + " NO-LOCK:") = FALSE) THEN
+          RETURN ERROR NEW FixtureError(SUBSTITUTE("Could not query data in source &1.", hBuffer:NAME)).
+        hQuery:QUERY-OPEN().
+        hQuery:GET-FIRST(NO-LOCK).
+        DO WHILE NOT hQuery:QUERY-OFF-END
+          ON ERROR UNDO, THROW:
+            hRBuffer:BUFFER-CREATE().
+            hRBuffer:BUFFER-COPY(hQBuffer).
+            hRBuffer:BUFFER-RELEASE().
+            hQuery:GET-NEXT().
+        END.
+        IF VALID-HANDLE(hRBuffer) THEN DELETE OBJECT hRBuffer.
+        IF VALID-HANDLE(hQBuffer) THEN DELETE OBJECT hQBuffer.
+        IF VALID-HANDLE(hQuery)   THEN DELETE OBJECT hQuery.
+      END.
+    END.
+  END METHOD.
+
+END CLASS.

--- a/src/OEUnit/Data/FixtureError.cls
+++ b/src/OEUnit/Data/FixtureError.cls
@@ -1,0 +1,18 @@
+/*------------------------------------------------------------------------------
+  File        :   FixtureError.cls
+  Package     :   OEUnit.Data
+  Description :   The exception thrown when Fixture encounters a problem.
+------------------------------------------------------------------------------*/
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+CLASS OEUnit.Data.FixtureError INHERITS Progress.Lang.AppError: 
+
+  /*----------------------------------------------------------------------------
+    Constructor. Accepts an error message.
+  ----------------------------------------------------------------------------*/    
+  CONSTRUCTOR PUBLIC FixtureError(INPUT errorMessage AS CHARACTER):
+    SUPER(errorMessage, 0).
+  END CONSTRUCTOR.
+
+END CLASS.

--- a/src/OEUnit/Reflection/MethodInfo.cls
+++ b/src/OEUnit/Reflection/MethodInfo.cls
@@ -129,6 +129,49 @@ CLASS OEUnit.Reflection.MethodInfo INHERITS StatementInfo:
     RETURN ERROR NEW StopConditionError("Stop condition occured").
   END METHOD.
 
+  /*----------------------------------------------------------------------------
+    Returns another MethodInfo object which holds the information regarding the
+    fixture method for this MethodInfo.
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC MethodInfo GetFixtureInfo():
+    RETURN GetAssociatedMethodInfo(INPUT OEUnitAnnotations:TestFixtureAttribute,
+                                   INPUT OEUnitAnnotations:Fixture,
+                                   INPUT OEUnitAnnotations:FixtureNameAttribute).
+  END METHOD.
+
+  /*----------------------------------------------------------------------------
+    Determines whether this method has a @Test annotation with a Fixture
+    attribute, and a method with a matching @Fixture attribute exists.
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC LOGICAL RequiresFixture():
+    RETURN (GetFixtureInfo() NE ?).
+  END METHOD.
+
+  /*----------------------------------------------------------------------------
+    Returns a Fixture object from the invocation of a Fixture method.
+  ----------------------------------------------------------------------------*/
+  METHOD PUBLIC Fixture GetFixture():
+    DEFINE VARIABLE fixtureMethod AS MethodInfo NO-UNDO.
+    DEFINE VARIABLE Fixture   AS Fixture NO-UNDO.
+    DO ON ERROR UNDO, THROW
+       ON QUIT UNDO, RETURN ERROR NEW QuitConditionError("Quit condition occured")
+       ON STOP UNDO, LEAVE:
+      fixtureMethod = GetFixtureInfo().
+      IF fixtureMethod NE ? AND VALID-OBJECT(fixtureMethod) THEN
+      DO:
+          IF fixtureMethod:IsStatic THEN
+            Fixture = DYNAMIC-INVOKE(fixtureMethod:ParentInfo:Name, fixtureMethod:Name).
+          ELSE
+            Fixture = DYNAMIC-INVOKE(fixtureMethod:ParentInfo:ClassInstance, fixtureMethod:Name).
+      END.
+      
+      RETURN Fixture.
+    END.
+
+    /* HACK: To accomodate bug in OpenEdge runtime, crashes when returning custom
+             error instances on stop conditions */
+    RETURN ERROR NEW StopConditionError("Stop condition occured").
+  END METHOD.
   
   /*----------------------------------------------------------------------------
     Returns another MethodInfo object for a method indicated in the attributes

--- a/src/OEUnit/Reflection/MethodInfo.cls
+++ b/src/OEUnit/Reflection/MethodInfo.cls
@@ -90,42 +90,9 @@ CLASS OEUnit.Reflection.MethodInfo INHERITS StatementInfo:
     data provider method for this MethodInfo.
   ----------------------------------------------------------------------------*/
   METHOD PUBLIC MethodInfo GetDataProviderInfo():
-
-    DEFINE VARIABLE annotation             AS AnnotationInfo NO-UNDO.
-    DEFINE VARIABLE dataProviderAnnotation AS AnnotationInfo NO-UNDO.
-    DEFINE VARIABLE dataProviders          AS List           NO-UNDO.
-    DEFINE VARIABLE dataProviderName       AS CHARACTER      NO-UNDO.
-    DEFINE VARIABLE dataProvider           AS MethodInfo     NO-UNDO.
-    DEFINE VARIABLE result                 AS LOGICAL        NO-UNDO INITIAL FALSE.
-
-    /* If this is a @Test, with a "DataProvider=" attribute, then attempt to
-     * find the data provider method
-     */
-    annotation = GetAnnotationOfType(OEUnitAnnotations:Test).
-
-    IF annotation NE ? AND annotation:HasAttribute("dataProvider") THEN
-    DO:
-      dataProviderName = annotation:Attributes:Get(OEUnitAnnotations:TestDataProviderAttribute).
-      dataProviders = parentInfo:GetAnnotatedMethods(OEUnitAnnotations:DataProvider).
-
-      /* Find first data provider with that name attribute or method name */
-      dataProviders:MoveFirst().
-      dataProviderLoop:
-      DO WHILE dataProviders:CURRENT NE ?:
-        dataProvider = CAST(dataProviders:CURRENT,"MethodInfo").
-        dataProviderAnnotation = dataProvider:GetAnnotationOfType(OEUnitAnnotations:DataProvider).
-        IF (dataProviderAnnotation:HasAttribute("name") = TRUE) THEN
-        DO:
-          IF dataProviderName = dataProviderAnnotation:Attributes:Get(OEUnitAnnotations:DataProviderNameAttribute) THEN
-            LEAVE dataProviderLoop.
-        END.
-        ELSE IF dataProvider:Name = dataProviderName THEN LEAVE dataProviderLoop.
-        ELSE dataProvider = ?.
-        dataProviders:MoveNext().
-      END.
-    END.
-
-    RETURN dataProvider.
+    RETURN GetAssociatedMethodInfo(INPUT OEUnitAnnotations:TestDataProviderAttribute,
+                                   INPUT OEUnitAnnotations:DataProvider,
+                                   INPUT OEUnitAnnotations:DataProviderNameAttribute).
   END METHOD.
 
   /*----------------------------------------------------------------------------
@@ -160,6 +127,52 @@ CLASS OEUnit.Reflection.MethodInfo INHERITS StatementInfo:
     /* HACK: To accomodate bug in OpenEdge runtime, crashes when returning custom
              error instances on stop conditions */
     RETURN ERROR NEW StopConditionError("Stop condition occured").
+  END METHOD.
+
+  
+  /*----------------------------------------------------------------------------
+    Returns another MethodInfo object for a method indicated in the attributes
+    in this MethodInfo.
+  ----------------------------------------------------------------------------*/
+  METHOD PROTECTED MethodInfo GetAssociatedMethodInfo(INPUT methodAttribute      AS CHARACTER,
+                                                      INPUT associatedAnnotation AS CHARACTER,
+                                                      INPUT associatedAttribute  AS CHARACTER):
+
+    DEFINE VARIABLE TestAnnotation       AS AnnotationInfo NO-UNDO.
+    DEFINE VARIABLE MethodAnnotation     AS AnnotationInfo NO-UNDO.
+    DEFINE VARIABLE AnnotatedMethods     AS List           NO-UNDO.
+    DEFINE VARIABLE AssociatedMethodName AS CHARACTER      NO-UNDO.
+    DEFINE VARIABLE AssociatedMethodInfo AS MethodInfo     NO-UNDO.
+    DEFINE VARIABLE result               AS LOGICAL        NO-UNDO INITIAL FALSE.
+
+    /* If this is a @Test, with a "Fixture=" attribute, then attempt to
+     * find the data provider method
+     */
+    TestAnnotation = GetAnnotationOfType(OEUnitAnnotations:Test).
+
+    IF TestAnnotation NE ? AND TestAnnotation:HasAttribute(methodAttribute) THEN
+    DO:
+      AssociatedMethodName = TestAnnotation:Attributes:Get(methodAttribute).
+      AnnotatedMethods = parentInfo:GetAnnotatedMethods(associatedAnnotation).
+
+      /* Find first data provider with that name attribute or method name */
+      AnnotatedMethods:MoveFirst().
+      MethodLoop:
+      DO WHILE AnnotatedMethods:CURRENT NE ?:
+        AssociatedMethodInfo = CAST(AnnotatedMethods:CURRENT,"MethodInfo").
+        MethodAnnotation = AssociatedMethodInfo:GetAnnotationOfType(associatedAnnotation).
+        IF (MethodAnnotation:HasAttribute(associatedAttribute) = TRUE) THEN
+        DO:
+          IF AssociatedMethodName = MethodAnnotation:Attributes:Get(associatedAttribute) THEN
+            LEAVE MethodLoop.
+        END.
+        ELSE IF AssociatedMethodInfo:Name = AssociatedMethodName THEN LEAVE MethodLoop.
+        ELSE AssociatedMethodInfo = ?.
+        AnnotatedMethods:MoveNext().
+      END.
+    END.
+
+    RETURN AssociatedMethodInfo.
   END METHOD.
 
 END CLASS.

--- a/src/OEUnit/Runners/OEUnitAnnotations.cls
+++ b/src/OEUnit/Runners/OEUnitAnnotations.cls
@@ -18,12 +18,23 @@ CLASS OEUnit.Runners.OEUnitAnnotations:
   DEFINE PUBLIC STATIC PROPERTY BeforeClass  AS CHARACTER NO-UNDO INIT "BeforeClass" GET.
   DEFINE PUBLIC STATIC PROPERTY AfterClass   AS CHARACTER NO-UNDO INIT "AfterClass" GET.
   DEFINE PUBLIC STATIC PROPERTY DataProvider AS CHARACTER NO-UNDO INIT "DataProvider" GET.
+  DEFINE PUBLIC STATIC PROPERTY Fixture      AS CHARACTER NO-UNDO INIT "Fixture" GET.
   
   /*----------------------------------------------------------------------------
     Expected Attribute for the Test Annotation.
   ----------------------------------------------------------------------------*/  
   DEFINE PUBLIC STATIC PROPERTY TestExpectedAttribute     AS CHARACTER NO-UNDO INIT "Expected" GET.
   DEFINE PUBLIC STATIC PROPERTY TestDataProviderAttribute AS CHARACTER NO-UNDO INIT "DataProvider" GET.
+  DEFINE PUBLIC STATIC PROPERTY TestFixtureAttribute      AS CHARACTER NO-UNDO INIT "Fixture" GET.
+  
+  /*----------------------------------------------------------------------------
+    Expected Attribute for the DataProvider Annotation.
+  ----------------------------------------------------------------------------*/ 
   DEFINE PUBLIC STATIC PROPERTY DataProviderNameAttribute AS CHARACTER NO-UNDO INIT "Name" GET.
+  
+  /*----------------------------------------------------------------------------
+    Expected Attribute for the Fixture Annotation.
+  ----------------------------------------------------------------------------*/ 
+  DEFINE PUBLIC STATIC PROPERTY FixtureNameAttribute      AS CHARACTER NO-UNDO INIT "Name" GET.
   
 END CLASS.

--- a/src/OEUnit/Runners/OEUnitRunner.cls
+++ b/src/OEUnit/Runners/OEUnitRunner.cls
@@ -204,17 +204,40 @@ CLASS OEUnit.Runners.OEUnitRunner INHERITS BaseRunner:
    END METHOD.
    
    /*----------------------------------------------------------------------------
-    Run a single test method with the given parameters and store it's result. Any
-    Progress.Lang.Errors thrown during the run are caught and stored in the
+    Run a single test method with the given parameters and store it's result. If
+    a test fixture is required, it will be extracted and a transaction started.
+    Any Progress.Lang.Errors thrown during the run are caught and stored in the
     result. 
   ----------------------------------------------------------------------------*/
    METHOD PROTECTED VOID RunTestMethod(INPUT testMethod AS MethodInfo, INPUT paramList AS Progress.Lang.ParameterList):
+       
+       IF testMethod:RequiresFixture() THEN
+       DO:
+           OEUnitFixtureTransaction:
+           DO TRANSACTION
+            ON ERROR UNDO, THROW:
+              RunTestMethod(INPUT testMethod, testMethod:GetFixture(), INPUT paramList).
+              UNDO OEUnitFixtureTransaction, LEAVE OEUnitFixtureTransaction.
+           END.
+       END.
+       ELSE 
+           RunTestMethod(INPUT testMethod, INPUT ?, INPUT paramList).
+   END METHOD.
+   
+   /*----------------------------------------------------------------------------
+    Run a single test method with the given fixure object and parameters and 
+    store it's result. If a fixture is provided, no transaction is started in
+    this method. Any Progress.Lang.Errors thrown during the run are caught and 
+    stored in the result. 
+  ----------------------------------------------------------------------------*/
+   METHOD PROTECTED VOID RunTestMethod(INPUT testMethod AS MethodInfo, INPUT testFixture AS Fixture, INPUT paramList AS Progress.Lang.ParameterList):
 
     DEFINE VARIABLE methodResult AS TestMethodResult NO-UNDO.
     methodResult = NEW TestMethodResult(testMethod).
     currentResult:AddResult(methodResult).
     IF ShouldRun(testMethod) THEN DO ON ERROR UNDO, THROW:
       NotifyOfTestStart(testMethod).
+      IF testFixture NE ? AND VALID-OBJECT(testFixture) THEN testFixture:CreateData().
       ETIME(TRUE).
       RunBefores(currentInfo:GetAnnotatedMethods(OEUnitAnnotations:Before)).
       ETIME(TRUE).

--- a/src/OEUnit/Runners/OEUnitRunner.cls
+++ b/src/OEUnit/Runners/OEUnitRunner.cls
@@ -211,17 +211,22 @@ CLASS OEUnit.Runners.OEUnitRunner INHERITS BaseRunner:
   ----------------------------------------------------------------------------*/
    METHOD PROTECTED VOID RunTestMethod(INPUT testMethod AS MethodInfo, INPUT paramList AS Progress.Lang.ParameterList):
        
-       IF testMethod:RequiresFixture() THEN
+       DEFINE VARIABLE fix AS Fixture NO-UNDO.
+       
+       IF testMethod:RequiresFixture() AND ShouldRun(testMethod) THEN
        DO:
            OEUnitFixtureTransaction:
-           DO TRANSACTION
-            ON ERROR UNDO, THROW:
-              RunTestMethod(INPUT testMethod, testMethod:GetFixture(), INPUT paramList).
+           DO TRANSACTION ON ERROR UNDO, THROW:
+              fix = testMethod:GetFixture().
+              RunTestMethod(INPUT testMethod, INPUT fix, INPUT paramList).
               UNDO OEUnitFixtureTransaction, LEAVE OEUnitFixtureTransaction.
            END.
+           DELETE OBJECT fix NO-ERROR.
        END.
-       ELSE 
+       ELSE
+       DO:
            RunTestMethod(INPUT testMethod, INPUT ?, INPUT paramList).
+       END.
    END METHOD.
    
    /*----------------------------------------------------------------------------
@@ -247,6 +252,7 @@ CLASS OEUnit.Runners.OEUnitRunner INHERITS BaseRunner:
         methodResult:AddError(err).
       END CATCH.
       FINALLY:
+        IF VALID-OBJECT(testFixture) THEN DELETE OBJECT testFixture.
         methodResult:SetDuration(ETIME).
         RunAfters(currentInfo:GetAnnotatedMethods(OEUnitAnnotations:After), methodResult).
         NotifyOfTestFinish(methodResult).

--- a/src/OEUnit/Runners/OEUnitRunner.cls
+++ b/src/OEUnit/Runners/OEUnitRunner.cls
@@ -237,7 +237,7 @@ CLASS OEUnit.Runners.OEUnitRunner INHERITS BaseRunner:
     currentResult:AddResult(methodResult).
     IF ShouldRun(testMethod) THEN DO ON ERROR UNDO, THROW:
       NotifyOfTestStart(testMethod).
-      IF testFixture NE ? AND VALID-OBJECT(testFixture) THEN testFixture:CreateData().
+      IF testFixture NE ? AND VALID-OBJECT(testFixture) AND TRANSACTION THEN testFixture:CreateData().
       ETIME(TRUE).
       RunBefores(currentInfo:GetAnnotatedMethods(OEUnitAnnotations:Before)).
       ETIME(TRUE).

--- a/src/OEUnit/Tests/Data/AllTestSuite.cls
+++ b/src/OEUnit/Tests/Data/AllTestSuite.cls
@@ -7,6 +7,7 @@ CLASS OEUnit.Tests.Data.AllTestSuite INHERITS TestSuite:
   
   CONSTRUCTOR AllTestSuite():
     AddTest(NEW DataProviderTest()).
+    AddTest(NEW FixtureTest()).
   END CONSTRUCTOR.
 
 END CLASS.

--- a/src/OEUnit/Tests/Data/AllTestSuite.cls
+++ b/src/OEUnit/Tests/Data/AllTestSuite.cls
@@ -7,6 +7,7 @@ CLASS OEUnit.Tests.Data.AllTestSuite INHERITS TestSuite:
   
   CONSTRUCTOR AllTestSuite():
     AddTest(NEW DataProviderTest()).
+    AddTest(NEW FixtureDataSetTest()).
     AddTest(NEW FixtureTest()).
   END CONSTRUCTOR.
 

--- a/src/OEUnit/Tests/Data/FixtureDataSetTest.cls
+++ b/src/OEUnit/Tests/Data/FixtureDataSetTest.cls
@@ -1,0 +1,198 @@
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+USING Progress.Lang.*.
+USING OEUnit.Tests.Data.*.
+USING OEUnit.Assertion.Assert.
+USING OEUnit.Data.Fixture.
+
+CLASS OEUnit.Tests.Data.FixtureDataSetTest: 
+    
+    DEFINE PROTECTED TEMP-TABLE ttTestTable NO-UNDO
+      FIELD StatusCode AS CHARACTER
+      FIELD Accepted   AS LOGICAL
+      INDEX StatusCode IS PRIMARY UNIQUE StatusCode ASCENDING.
+    
+    DEFINE VARIABLE fixture AS Fixture NO-UNDO.
+
+    @After.
+    METHOD PUBLIC VOID DeleteFixture():
+        DELETE OBJECT fixture NO-ERROR.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID FromJSON():
+        fixture = NEW Fixture().
+        fixture:FromJSON("~{ ~"FirstTable~": ["
+                         + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
+                         + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0},"
+                         + " ], "
+                         + " ~"SecondTable~": ["
+                         + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
+                         + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0}"
+                         + "]}").
+        Assert:AreEqual(fixture:TableCount, 2).
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID FromJSON_Reset():
+        fixture = NEW Fixture().
+        fixture:FromJSON("~{ ~"FirstTable~": ["
+                         + "~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
+                         + "~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0},"
+                         + "]}").
+        Assert:AreEqual(fixture:TableCount, 1).
+        fixture:FromJSON("~{ ~"FirstTable~": ["
+                         + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
+                         + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0},"
+                         + " ], "
+                         + " ~"SecondTable~": ["
+                         + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
+                         + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0}"
+                         + "]}").
+        Assert:AreEqual(fixture:TableCount, 2).
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID FromXML():
+        fixture = NEW Fixture().
+        fixture:FromXML('<?xml version="1.0"?>'
+                        + '<ProDataSet>'
+                        +   '<FirstTable>'
+                        +     '<status>NEW</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        +   '<FirstTable>'
+                        +     '<status>ACCEPTED</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        +   '<SecondTable>'
+                        +     '<status>ACCEPTED</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</SecondTable>'
+                        + '</ProDataSet>').
+        Assert:AreEqual(fixture:TableCount, 2).
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID FromXML_Reset():
+        fixture = NEW Fixture().
+        fixture:FromXML('<?xml version="1.0"?>'
+                        + '<ProDataSet>'
+                        +   '<FirstTable>'
+                        +     '<status>NEW</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        +   '<FirstTable>'
+                        +     '<status>ACCEPTED</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        + '</ProDataSet>').
+        Assert:AreEqual(fixture:TableCount, 1).
+        fixture:FromXML('<?xml version="1.0"?>'
+                        + '<ProDataSet>'
+                        +   '<FirstTable>'
+                        +     '<status>NEW</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        +   '<FirstTable>'
+                        +     '<status>ACCEPTED</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        +   '<SecondTable>'
+                        +     '<status>ACCEPTED</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</SecondTable>'
+                        + '</ProDataSet>').
+        Assert:AreEqual(fixture:TableCount, 2).
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID FromDataSet():
+        
+        DEFINE VARIABLE httTest   AS HANDLE NO-UNDO.
+        DEFINE VARIABLE hdSet     AS HANDLE NO-UNDO.
+        DEFINE VARIABLE htt       AS HANDLE NO-UNDO.
+        DEFINE VARIABLE hdSource  AS HANDLE NO-UNDO.
+        DEFINE VARIABLE httBuffer AS HANDLE NO-UNDO.
+
+        fixture = NEW Fixture().
+        EMPTY TEMP-TABLE ttTestTable.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "NEW"
+               ttTestTable.Accepted = TRUE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "ACCEPTED"
+               ttTestTable.Accepted = TRUE.
+               
+        ASSIGN httTest = TEMP-TABLE ttTestTable:HANDLE.
+               
+        CREATE TEMP-TABLE htt.
+        htt:COPY-TEMP-TABLE(httTest, FALSE, TRUE).
+        
+        httBuffer = htt:DEFAULT-BUFFER-HANDLE.
+        
+        CREATE DATASET hdSet.
+        hdSet:ADD-BUFFER(httBuffer).
+        
+        CREATE DATA-SOURCE hdSource.
+        hdSource:ADD-SOURCE-BUFFER(httTest:DEFAULT-BUFFER-HANDLE,?).
+        httBuffer:ATTACH-DATA-SOURCE(hdSource).
+        hdSet:FILL().
+        fixture:FromDataSet(hdSet).
+        Assert:AreEqual(fixture:TableCount, 1).
+        
+    END METHOD.
+    /*
+    @Test.
+    METHOD PUBLIC VOID FromTempTable_Reset():
+        fixture = NEW Fixture().
+        EMPTY TEMP-TABLE ttTestTable.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "NEW"
+               ttTestTable.Accepted = TRUE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "ACCEPTED"
+               ttTestTable.Accepted = TRUE.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "PICKING"
+               ttTestTable.Accepted = FALSE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "POSTED"
+               ttTestTable.Accepted = FALSE.
+        fixture:FromTempTable(TEMP-TABLE ttTestTable:HANDLE).
+        /*Assert:AreEqual(fixture:Size, 4).*/
+        EMPTY TEMP-TABLE ttTestTable.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "NEW"
+               ttTestTable.Accepted = TRUE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "ACCEPTED"
+               ttTestTable.Accepted = TRUE.
+        fixture:FromTempTable(TEMP-TABLE ttTestTable:HANDLE).
+        /*Assert:AreEqual(fixture:Size, 2).*/
+    END METHOD.
+    */
+    
+    @Test.
+    METHOD PUBLIC VOID FromTempTable():
+        
+        DEFINE VARIABLE httTest   AS HANDLE NO-UNDO.
+        DEFINE VARIABLE hdSet     AS HANDLE NO-UNDO.
+        DEFINE VARIABLE htt       AS HANDLE NO-UNDO.
+        DEFINE VARIABLE hdSource  AS HANDLE NO-UNDO.
+        DEFINE VARIABLE httBuffer AS HANDLE NO-UNDO.
+
+        fixture = NEW Fixture().
+        EMPTY TEMP-TABLE ttTestTable.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "NEW"
+               ttTestTable.Accepted = TRUE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "ACCEPTED"
+               ttTestTable.Accepted = TRUE.
+               
+        fixture:FromTempTable(TEMP-TABLE ttTestTable:HANDLE).
+        Assert:AreEqual(fixture:TableCount,1).
+    END.
+END CLASS.

--- a/src/OEUnit/Tests/Data/FixtureDataSetTest.cls
+++ b/src/OEUnit/Tests/Data/FixtureDataSetTest.cls
@@ -4,7 +4,7 @@ ROUTINE-LEVEL ON ERROR UNDO, THROW.
 USING Progress.Lang.*.
 USING OEUnit.Tests.Data.*.
 USING OEUnit.Assertion.Assert.
-USING OEUnit.Data.Fixture.
+USING OEUnit.Data.FixtureDataSet.
 
 CLASS OEUnit.Tests.Data.FixtureDataSetTest: 
     
@@ -13,16 +13,16 @@ CLASS OEUnit.Tests.Data.FixtureDataSetTest:
       FIELD Accepted   AS LOGICAL
       INDEX StatusCode IS PRIMARY UNIQUE StatusCode ASCENDING.
     
-    DEFINE VARIABLE fixture AS Fixture NO-UNDO.
+    DEFINE VARIABLE fixture AS FixtureDataSet NO-UNDO.
 
     @After.
-    METHOD PUBLIC VOID DeleteFixture():
+    METHOD PUBLIC VOID DeleteFixtureDataSet():
         DELETE OBJECT fixture NO-ERROR.
     END METHOD.
     
     @Test.
     METHOD PUBLIC VOID FromJSON():
-        fixture = NEW Fixture().
+        fixture = NEW FixtureDataSet().
         fixture:FromJSON("~{ ~"FirstTable~": ["
                          + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
                          + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0},"
@@ -36,7 +36,7 @@ CLASS OEUnit.Tests.Data.FixtureDataSetTest:
     
     @Test.
     METHOD PUBLIC VOID FromJSON_Reset():
-        fixture = NEW Fixture().
+        fixture = NEW FixtureDataSet().
         fixture:FromJSON("~{ ~"FirstTable~": ["
                          + "~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
                          + "~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0},"
@@ -55,7 +55,7 @@ CLASS OEUnit.Tests.Data.FixtureDataSetTest:
     
     @Test.
     METHOD PUBLIC VOID FromXML():
-        fixture = NEW Fixture().
+        fixture = NEW FixtureDataSet().
         fixture:FromXML('<?xml version="1.0"?>'
                         + '<ProDataSet>'
                         +   '<FirstTable>'
@@ -76,7 +76,7 @@ CLASS OEUnit.Tests.Data.FixtureDataSetTest:
     
     @Test.
     METHOD PUBLIC VOID FromXML_Reset():
-        fixture = NEW Fixture().
+        fixture = NEW FixtureDataSet().
         fixture:FromXML('<?xml version="1.0"?>'
                         + '<ProDataSet>'
                         +   '<FirstTable>'
@@ -116,7 +116,7 @@ CLASS OEUnit.Tests.Data.FixtureDataSetTest:
         DEFINE VARIABLE hdSource  AS HANDLE NO-UNDO.
         DEFINE VARIABLE httBuffer AS HANDLE NO-UNDO.
 
-        fixture = NEW Fixture().
+        fixture = NEW FixtureDataSet().
         EMPTY TEMP-TABLE ttTestTable.
         CREATE ttTestTable.
         ASSIGN ttTestTable.StatusCode = "NEW"
@@ -146,7 +146,7 @@ CLASS OEUnit.Tests.Data.FixtureDataSetTest:
     /*
     @Test.
     METHOD PUBLIC VOID FromTempTable_Reset():
-        fixture = NEW Fixture().
+        fixture = NEW FixtureDataSet().
         EMPTY TEMP-TABLE ttTestTable.
         CREATE ttTestTable.
         ASSIGN ttTestTable.StatusCode = "NEW"
@@ -183,7 +183,7 @@ CLASS OEUnit.Tests.Data.FixtureDataSetTest:
         DEFINE VARIABLE hdSource  AS HANDLE NO-UNDO.
         DEFINE VARIABLE httBuffer AS HANDLE NO-UNDO.
 
-        fixture = NEW Fixture().
+        fixture = NEW FixtureDataSet().
         EMPTY TEMP-TABLE ttTestTable.
         CREATE ttTestTable.
         ASSIGN ttTestTable.StatusCode = "NEW"

--- a/src/OEUnit/Tests/Data/FixtureTest.cls
+++ b/src/OEUnit/Tests/Data/FixtureTest.cls
@@ -116,46 +116,36 @@ CLASS OEUnit.Tests.Data.FixtureTest:
         Assert:AreEqual(fixture:Size, 2).
     END METHOD.
     
-    @Test.
-    METHOD PUBLIC VOID FromDataSet():
+    METHOD PROTECTED HANDLE CreateDataSetFromTempTable(INPUT httTest AS HANDLE):
         
-        DEFINE VARIABLE httTest   AS HANDLE NO-UNDO.
         DEFINE VARIABLE hdSet     AS HANDLE NO-UNDO.
         DEFINE VARIABLE htt       AS HANDLE NO-UNDO.
         DEFINE VARIABLE hdSource  AS HANDLE NO-UNDO.
         DEFINE VARIABLE httBuffer AS HANDLE NO-UNDO.
-
-        fixture = NEW Fixture().
-        EMPTY TEMP-TABLE ttTestTable.
-        CREATE ttTestTable.
-        ASSIGN ttTestTable.StatusCode = "NEW"
-               ttTestTable.Accepted = TRUE. 
-        CREATE ttTestTable.
-        ASSIGN ttTestTable.StatusCode = "ACCEPTED"
-               ttTestTable.Accepted = TRUE.
-               
-        ASSIGN httTest = TEMP-TABLE ttTestTable:HANDLE.
-               
+        DEFINE VARIABLE httTestBuf AS HANDLE NO-UNDO.
+        
         CREATE TEMP-TABLE htt.
         htt:COPY-TEMP-TABLE(httTest, FALSE, TRUE).
-        
-        httBuffer = htt:DEFAULT-BUFFER-HANDLE.
+
+        /* Create buffers for temp-tables */        
+        CREATE BUFFER httBuffer FOR TABLE htt.
+        CREATE BUFFER httTestBuf FOR TABLE httTest.
         
         CREATE DATASET hdSet.
         hdSet:ADD-BUFFER(httBuffer).
         
         CREATE DATA-SOURCE hdSource.
-        hdSource:ADD-SOURCE-BUFFER(httTest:DEFAULT-BUFFER-HANDLE,?).
+        hdSource:ADD-SOURCE-BUFFER(httTestBuf,?).
         httBuffer:ATTACH-DATA-SOURCE(hdSource).
         hdSet:FILL().
-        fixture:FromDataSet(hdSet).
-        Assert:AreEqual(fixture:TableCount, 1).
-        Assert:AreEqual(fixture:Size, 1).
+        
+        RETURN hdSet.
         
     END METHOD.
-    /*
+    
     @Test.
-    METHOD PUBLIC VOID FromTempTable_Reset():
+    METHOD PUBLIC VOID FromDataSet():
+        
         fixture = NEW Fixture().
         EMPTY TEMP-TABLE ttTestTable.
         CREATE ttTestTable.
@@ -164,14 +154,20 @@ CLASS OEUnit.Tests.Data.FixtureTest:
         CREATE ttTestTable.
         ASSIGN ttTestTable.StatusCode = "ACCEPTED"
                ttTestTable.Accepted = TRUE.
-        CREATE ttTestTable.
-        ASSIGN ttTestTable.StatusCode = "PICKING"
-               ttTestTable.Accepted = FALSE. 
-        CREATE ttTestTable.
-        ASSIGN ttTestTable.StatusCode = "POSTED"
-               ttTestTable.Accepted = FALSE.
-        fixture:FromTempTable(TEMP-TABLE ttTestTable:HANDLE).
-        /*Assert:AreEqual(fixture:Size, 4).*/
+               
+        fixture:FromDataSet(CreateDataSetFromTempTable(INPUT TEMP-TABLE ttTestTable:HANDLE)).
+        Assert:AreEqual(fixture:TableCount, 1).
+        Assert:AreEqual(fixture:Size, 1).
+        
+    END METHOD.
+
+    @Test.
+    METHOD PUBLIC VOID FromDataSet_Multiple():
+        
+        DEFINE BUFFER ttBufTestTable FOR ttTestTable.
+        DEFINE BUFFER ttSecondTestTable FOR ttSecondTestTable.
+        
+        fixture = NEW Fixture().
         EMPTY TEMP-TABLE ttTestTable.
         CREATE ttTestTable.
         ASSIGN ttTestTable.StatusCode = "NEW"
@@ -179,10 +175,24 @@ CLASS OEUnit.Tests.Data.FixtureTest:
         CREATE ttTestTable.
         ASSIGN ttTestTable.StatusCode = "ACCEPTED"
                ttTestTable.Accepted = TRUE.
-        fixture:FromTempTable(TEMP-TABLE ttTestTable:HANDLE).
-        /*Assert:AreEqual(fixture:Size, 2).*/
+               
+        fixture:FromDataSet(CreateDataSetFromTempTable(INPUT TEMP-TABLE ttBufTestTable:HANDLE)).
+        Assert:AreEqual(fixture:TableCount, 1).
+        Assert:AreEqual(fixture:Size, 1).
+
+        EMPTY TEMP-TABLE ttSecondTestTable.
+        CREATE ttSecondTestTable.
+        ASSIGN ttSecondTestTable.StatusCode = "NEW"
+               ttSecondTestTable.Accepted = TRUE. 
+        CREATE ttSecondTestTable.
+        ASSIGN ttSecondTestTable.StatusCode = "ACCEPTED"
+               ttSecondTestTable.Accepted = TRUE.
+               
+        fixture:FromDataSet(CreateDataSetFromTempTable(INPUT TEMP-TABLE ttSecondTestTable:HANDLE)).
+        Assert:AreEqual(fixture:TableCount, 2).
+        Assert:AreEqual(fixture:Size, 2).
+
     END METHOD.
-    */
     
     @Test.
     METHOD PUBLIC VOID FromTempTable():

--- a/src/OEUnit/Tests/Data/FixtureTest.cls
+++ b/src/OEUnit/Tests/Data/FixtureTest.cls
@@ -39,7 +39,7 @@ CLASS OEUnit.Tests.Data.FixtureTest:
     END METHOD.
     
     @Test.
-    METHOD PUBLIC VOID FromJSON_Reset():
+    METHOD PUBLIC VOID FromJSON_Multiple():
         fixture = NEW Fixture().
         fixture:FromJSON("~{ ~"FirstTable~": ["
                          + "~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
@@ -82,7 +82,7 @@ CLASS OEUnit.Tests.Data.FixtureTest:
     END METHOD.
     
     @Test.
-    METHOD PUBLIC VOID FromXML_Reset():
+    METHOD PUBLIC VOID FromXML_Multiple():
         fixture = NEW Fixture().
         fixture:FromXML('<?xml version="1.0"?>'
                         + '<ProDataSet>'

--- a/src/OEUnit/Tests/Data/FixtureTest.cls
+++ b/src/OEUnit/Tests/Data/FixtureTest.cls
@@ -13,6 +13,9 @@ CLASS OEUnit.Tests.Data.FixtureTest:
       FIELD Accepted   AS LOGICAL
       INDEX StatusCode IS PRIMARY UNIQUE StatusCode ASCENDING.
     
+    DEFINE PROTECTED TEMP-TABLE ttSecondTestTable NO-UNDO
+      LIKE ttTestTable.
+    
     DEFINE VARIABLE fixture AS Fixture NO-UNDO.
 
     @After.
@@ -32,6 +35,7 @@ CLASS OEUnit.Tests.Data.FixtureTest:
                          + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0}"
                          + "]}").
         Assert:AreEqual(fixture:TableCount, 2).
+        Assert:AreEqual(fixture:Size, 1).
     END METHOD.
     
     @Test.
@@ -42,6 +46,7 @@ CLASS OEUnit.Tests.Data.FixtureTest:
                          + "~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0},"
                          + "]}").
         Assert:AreEqual(fixture:TableCount, 1).
+        Assert:AreEqual(fixture:Size, 1).
         fixture:FromJSON("~{ ~"FirstTable~": ["
                          + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
                          + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0},"
@@ -50,7 +55,8 @@ CLASS OEUnit.Tests.Data.FixtureTest:
                          + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
                          + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0}"
                          + "]}").
-        Assert:AreEqual(fixture:TableCount, 2).
+        Assert:AreEqual(fixture:TableCount, 3).
+        Assert:AreEqual(fixture:Size, 2).
     END METHOD.
     
     @Test.
@@ -72,6 +78,7 @@ CLASS OEUnit.Tests.Data.FixtureTest:
                         +   '</SecondTable>'
                         + '</ProDataSet>').
         Assert:AreEqual(fixture:TableCount, 2).
+        Assert:AreEqual(fixture:Size, 1).
     END METHOD.
     
     @Test.
@@ -89,6 +96,7 @@ CLASS OEUnit.Tests.Data.FixtureTest:
                         +   '</FirstTable>'
                         + '</ProDataSet>').
         Assert:AreEqual(fixture:TableCount, 1).
+        Assert:AreEqual(fixture:Size, 1).
         fixture:FromXML('<?xml version="1.0"?>'
                         + '<ProDataSet>'
                         +   '<FirstTable>'
@@ -104,7 +112,8 @@ CLASS OEUnit.Tests.Data.FixtureTest:
                         +     '<accepted>true</accepted>'
                         +   '</SecondTable>'
                         + '</ProDataSet>').
-        Assert:AreEqual(fixture:TableCount, 2).
+        Assert:AreEqual(fixture:TableCount, 3).
+        Assert:AreEqual(fixture:Size, 2).
     END METHOD.
     
     @Test.
@@ -141,6 +150,7 @@ CLASS OEUnit.Tests.Data.FixtureTest:
         hdSet:FILL().
         fixture:FromDataSet(hdSet).
         Assert:AreEqual(fixture:TableCount, 1).
+        Assert:AreEqual(fixture:Size, 1).
         
     END METHOD.
     /*
@@ -194,5 +204,37 @@ CLASS OEUnit.Tests.Data.FixtureTest:
                
         fixture:FromTempTable(TEMP-TABLE ttTestTable:HANDLE).
         Assert:AreEqual(fixture:TableCount,1).
+        Assert:AreEqual(fixture:Size, 1).
     END.
+
+    @Test.
+    METHOD PUBLIC VOID FromTempTable_Multiple():
+        fixture = NEW Fixture().
+        EMPTY TEMP-TABLE ttTestTable.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "NEW"
+               ttTestTable.Accepted = TRUE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "ACCEPTED"
+               ttTestTable.Accepted = TRUE.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "PICKING"
+               ttTestTable.Accepted = FALSE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "POSTED"
+               ttTestTable.Accepted = FALSE.
+        fixture:FromTempTable(TEMP-TABLE ttTestTable:HANDLE).
+        Assert:AreEqual(fixture:TableCount, 1).
+        Assert:AreEqual(fixture:Size, 1).
+        EMPTY TEMP-TABLE ttSecondTestTable.
+        CREATE ttSecondTestTable.
+        ASSIGN ttSecondTestTable.StatusCode = "NEW"
+               ttSecondTestTable.Accepted = TRUE. 
+        CREATE ttSecondTestTable.
+        ASSIGN ttSecondTestTable.StatusCode = "ACCEPTED"
+               ttSecondTestTable.Accepted = TRUE.
+        fixture:FromTempTable(TEMP-TABLE ttSecondTestTable:HANDLE).
+        Assert:AreEqual(fixture:TableCount, 2).
+        Assert:AreEqual(fixture:Size, 2).
+    END METHOD.
 END CLASS.

--- a/src/OEUnit/Tests/Data/FixtureTest.cls
+++ b/src/OEUnit/Tests/Data/FixtureTest.cls
@@ -1,0 +1,198 @@
+
+ROUTINE-LEVEL ON ERROR UNDO, THROW.
+
+USING Progress.Lang.*.
+USING OEUnit.Tests.Data.*.
+USING OEUnit.Assertion.Assert.
+USING OEUnit.Data.Fixture.
+
+CLASS OEUnit.Tests.Data.FixtureTest: 
+    
+    DEFINE PROTECTED TEMP-TABLE ttTestTable NO-UNDO
+      FIELD StatusCode AS CHARACTER
+      FIELD Accepted   AS LOGICAL
+      INDEX StatusCode IS PRIMARY UNIQUE StatusCode ASCENDING.
+    
+    DEFINE VARIABLE fixture AS Fixture NO-UNDO.
+
+    @After.
+    METHOD PUBLIC VOID DeleteFixture():
+        DELETE OBJECT fixture NO-ERROR.
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID FromJSON():
+        fixture = NEW Fixture().
+        fixture:FromJSON("~{ ~"FirstTable~": ["
+                         + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
+                         + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0},"
+                         + " ], "
+                         + " ~"SecondTable~": ["
+                         + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
+                         + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0}"
+                         + "]}").
+        Assert:AreEqual(fixture:TableCount, 2).
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID FromJSON_Reset():
+        fixture = NEW Fixture().
+        fixture:FromJSON("~{ ~"FirstTable~": ["
+                         + "~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
+                         + "~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0},"
+                         + "]}").
+        Assert:AreEqual(fixture:TableCount, 1).
+        fixture:FromJSON("~{ ~"FirstTable~": ["
+                         + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
+                         + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0},"
+                         + " ], "
+                         + " ~"SecondTable~": ["
+                         + "  ~{ ~"name~": ~"Char Value~", ~"intvalue~": 0, ~"bool~": true, ~"nullvalue~": null},"
+                         + "  ~{ ~"name~": ~"Next Value~", ~"intvalue~": 15, ~"bool~": false, ~"nullvalue~": 0}"
+                         + "]}").
+        Assert:AreEqual(fixture:TableCount, 2).
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID FromXML():
+        fixture = NEW Fixture().
+        fixture:FromXML('<?xml version="1.0"?>'
+                        + '<ProDataSet>'
+                        +   '<FirstTable>'
+                        +     '<status>NEW</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        +   '<FirstTable>'
+                        +     '<status>ACCEPTED</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        +   '<SecondTable>'
+                        +     '<status>ACCEPTED</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</SecondTable>'
+                        + '</ProDataSet>').
+        Assert:AreEqual(fixture:TableCount, 2).
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID FromXML_Reset():
+        fixture = NEW Fixture().
+        fixture:FromXML('<?xml version="1.0"?>'
+                        + '<ProDataSet>'
+                        +   '<FirstTable>'
+                        +     '<status>NEW</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        +   '<FirstTable>'
+                        +     '<status>ACCEPTED</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        + '</ProDataSet>').
+        Assert:AreEqual(fixture:TableCount, 1).
+        fixture:FromXML('<?xml version="1.0"?>'
+                        + '<ProDataSet>'
+                        +   '<FirstTable>'
+                        +     '<status>NEW</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        +   '<FirstTable>'
+                        +     '<status>ACCEPTED</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</FirstTable>'
+                        +   '<SecondTable>'
+                        +     '<status>ACCEPTED</status>'
+                        +     '<accepted>true</accepted>'
+                        +   '</SecondTable>'
+                        + '</ProDataSet>').
+        Assert:AreEqual(fixture:TableCount, 2).
+    END METHOD.
+    
+    @Test.
+    METHOD PUBLIC VOID FromDataSet():
+        
+        DEFINE VARIABLE httTest   AS HANDLE NO-UNDO.
+        DEFINE VARIABLE hdSet     AS HANDLE NO-UNDO.
+        DEFINE VARIABLE htt       AS HANDLE NO-UNDO.
+        DEFINE VARIABLE hdSource  AS HANDLE NO-UNDO.
+        DEFINE VARIABLE httBuffer AS HANDLE NO-UNDO.
+
+        fixture = NEW Fixture().
+        EMPTY TEMP-TABLE ttTestTable.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "NEW"
+               ttTestTable.Accepted = TRUE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "ACCEPTED"
+               ttTestTable.Accepted = TRUE.
+               
+        ASSIGN httTest = TEMP-TABLE ttTestTable:HANDLE.
+               
+        CREATE TEMP-TABLE htt.
+        htt:COPY-TEMP-TABLE(httTest, FALSE, TRUE).
+        
+        httBuffer = htt:DEFAULT-BUFFER-HANDLE.
+        
+        CREATE DATASET hdSet.
+        hdSet:ADD-BUFFER(httBuffer).
+        
+        CREATE DATA-SOURCE hdSource.
+        hdSource:ADD-SOURCE-BUFFER(httTest:DEFAULT-BUFFER-HANDLE,?).
+        httBuffer:ATTACH-DATA-SOURCE(hdSource).
+        hdSet:FILL().
+        fixture:FromDataSet(hdSet).
+        Assert:AreEqual(fixture:TableCount, 1).
+        
+    END METHOD.
+    /*
+    @Test.
+    METHOD PUBLIC VOID FromTempTable_Reset():
+        fixture = NEW Fixture().
+        EMPTY TEMP-TABLE ttTestTable.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "NEW"
+               ttTestTable.Accepted = TRUE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "ACCEPTED"
+               ttTestTable.Accepted = TRUE.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "PICKING"
+               ttTestTable.Accepted = FALSE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "POSTED"
+               ttTestTable.Accepted = FALSE.
+        fixture:FromTempTable(TEMP-TABLE ttTestTable:HANDLE).
+        /*Assert:AreEqual(fixture:Size, 4).*/
+        EMPTY TEMP-TABLE ttTestTable.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "NEW"
+               ttTestTable.Accepted = TRUE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "ACCEPTED"
+               ttTestTable.Accepted = TRUE.
+        fixture:FromTempTable(TEMP-TABLE ttTestTable:HANDLE).
+        /*Assert:AreEqual(fixture:Size, 2).*/
+    END METHOD.
+    */
+    
+    @Test.
+    METHOD PUBLIC VOID FromTempTable():
+        
+        DEFINE VARIABLE httTest   AS HANDLE NO-UNDO.
+        DEFINE VARIABLE hdSet     AS HANDLE NO-UNDO.
+        DEFINE VARIABLE htt       AS HANDLE NO-UNDO.
+        DEFINE VARIABLE hdSource  AS HANDLE NO-UNDO.
+        DEFINE VARIABLE httBuffer AS HANDLE NO-UNDO.
+
+        fixture = NEW Fixture().
+        EMPTY TEMP-TABLE ttTestTable.
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "NEW"
+               ttTestTable.Accepted = TRUE. 
+        CREATE ttTestTable.
+        ASSIGN ttTestTable.StatusCode = "ACCEPTED"
+               ttTestTable.Accepted = TRUE.
+               
+        fixture:FromTempTable(TEMP-TABLE ttTestTable:HANDLE).
+        Assert:AreEqual(fixture:TableCount,1).
+    END.
+END CLASS.


### PR DESCRIPTION
This change implements Fixtures for a connected database, allowing data to be be imported at the start of a test method, and removed at the end of the test method (inside of a single transaction.)

Data is loaded through DataSets, Temp-Tables, JSON and XML files. Tests are annotated with a 'Fixture' annotation, and an associated class method is run, returning a Fixture object containing the DataSets to load. Multiple datasets can be be loaded per Fixture, and each fixture method can be used with more than one test method.
