### PR TITLE
OEUnit can handle more unit tests.

### DIFF
--- a/src/OEUnit/Automation/Pct/RunTests.p
+++ b/src/OEUnit/Automation/Pct/RunTests.p
@@ -94,7 +94,7 @@ PROCEDURE FindClassFiles PRIVATE:
 
     CASE SUBSTRING(FILE-INFO:FILE-TYPE, 1, 1):
       WHEN "F" THEN DO:
-        IF directoryEntry MATCHES ("Test*.cls") THEN DO:            
+        IF directoryEntry MATCHES ("*.cls") THEN DO:            
             CREATE b_ClassFile.
             b_ClassFile.classFile = FILE-INFO:FULL-PATHNAME.
         END.


### PR DESCRIPTION
Because the code holds all unit test classes in one LONGCHAR variable, a limit is set on the number of unit tests which can be ran.

This is fixed by replacing the LONGCHAR variable 'classFiles' by a TEMP-TABLE 'ttClassFiles' which holds all unit test classes.

Resolve issue :
14:06:22    [PCTRun] RUN OEUnit/Automation/Pct/RunFromCommandLine
14:06:22    [PCTRun] Attempt to exceed maximum size of a CHARACTER variable. (9324)
14:06:22    [PCTRun] ** Unable to update  Field. (142)