### PR TITLE
Fix error when exporting failure with '<' sign.

### DIFF
--- a/src/OEUnit/Automation/SureFireReporter.cls
+++ b/src/OEUnit/Automation/SureFireReporter.cls
@@ -80,7 +80,7 @@ CLASS OEUnit.Automation.SureFireReporter INHERITS BaseReporter:
           + SUBSTITUTE('>~n    <failure'
               /* + ' type="??"' */
               + ' message="&1">~n',
-            currentResult:GetMessage()).
+            REPLACE(currentResult:GetMessage(), "<":U, "&lt;":U)).
 
         /* loop through the list of errors */  
         errorList = currentResult:GetErrors().
@@ -95,11 +95,10 @@ CLASS OEUnit.Automation.SureFireReporter INHERITS BaseReporter:
           END.
 
           outputXml = outputXml
-            + SUBSTITUTE('&1 at &2',
+            + REPLACE(SUBSTITUTE('&1 at &2',
                 currentResult:GetMessage(),
-                errorStack).
+                errorStack), "<":U, "&lt;":U).
         END.
-
         /* close the testcase tag */
         outputXml = outputXml
           + '~n    </failure>~n  </testcase>~n'.


### PR DESCRIPTION
When reporting a failure with SureFireReporter, the class gave an progress exception because the exporting of the less than sign ('<') is not supported.

We can replace this character by '&lt;', this fixed the problem, and does export a proper xml.

The progress error : 
`4GL 4GLTRACE       Return from RunClassAsTest [OEUnit/Automation/Pct/RunTests] ERROR
4GL -- (Procedure: 'OEUnit/Automation/Pct/RunTests' Line:41) X-NODEREF or X-DOCUMENT LOAD got an error: FATAL ERROR: file 'MEMPTR', line '3', column '0', message ''<' character cannot be used in attribute value 'message'; use &lt; instead'. (9082)
4GL 4GLTRACE       Run RunClassAsTest "C:\workspace\Samplenet\samplenet_12_pro\samplenet-abl-sources\test\be\mips\samplenet\manual\samplelog\TestSampleLogFinder.cls" [Main Block - OEUnit/Automation/Pct/RunTests @ 41]`

See attached screenshot of OEUnit in eclipse which can not be exported with the SureFireReporter.

![oeunitlog](https://cloud.githubusercontent.com/assets/20811052/19073158/b980cf4a-8a39-11e6-9d17-97144953238b.png)
